### PR TITLE
Fix for issue #11

### DIFF
--- a/src/main/java/com/ivanff/signEditor/SignEditorMod.java
+++ b/src/main/java/com/ivanff/signEditor/SignEditorMod.java
@@ -11,7 +11,7 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
-import net.minecraft.item.SignItem;
+import net.minecraft.item.BlockItem;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
@@ -40,7 +40,7 @@ public class SignEditorMod implements ModInitializer {
         UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
             BlockPos pos = hitResult.getBlockPos();
             BlockEntity blockEntity = world.getBlockEntity(pos);
-            if (blockEntity instanceof SignBlockEntity && isNotHoldingSign(player)) {
+            if (blockEntity instanceof SignBlockEntity && hasEmptyHand(player)) {
                 if (player.isSneaking()) {
                     SignBlockEntity signBlock = (SignBlockEntity) blockEntity;
                     ((SignEntityMixin) signBlock).setSignEditable(true);
@@ -80,9 +80,9 @@ public class SignEditorMod implements ModInitializer {
         hangingState.getBlock().onUse(hangingState, world, hangingPos, player, hand, hangingHitResult);
     }
 
-    boolean isNotHoldingSign(PlayerEntity player) {
+    boolean hasEmptyHand(PlayerEntity player) {
         Item mainHandItem = player.getEquippedStack(EquipmentSlot.MAINHAND).getItem();
         Item offHandItem = player.getEquippedStack(EquipmentSlot.OFFHAND).getItem();
-        return !(mainHandItem instanceof SignItem || offHandItem instanceof SignItem);
+        return mainHandItem is null && !(offHandItem instanceof BlockItem);
     } 
 }

--- a/src/main/java/com/ivanff/signEditor/SignEditorMod.java
+++ b/src/main/java/com/ivanff/signEditor/SignEditorMod.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.BlockItem;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.ActionResult;
@@ -81,8 +82,8 @@ public class SignEditorMod implements ModInitializer {
     }
 
     boolean hasEmptyHand(PlayerEntity player) {
-        Item mainHandItem = player.getEquippedStack(EquipmentSlot.MAINHAND).getItem();
+        ItemStack mainHandStack = player.getEquippedStack(EquipmentSlot.MAINHAND);
         Item offHandItem = player.getEquippedStack(EquipmentSlot.OFFHAND).getItem();
-        return mainHandItem == null && !(offHandItem instanceof BlockItem);
+        return mainHandStack.isEmpty() && !(offHandItem instanceof BlockItem);
     } 
 }

--- a/src/main/java/com/ivanff/signEditor/SignEditorMod.java
+++ b/src/main/java/com/ivanff/signEditor/SignEditorMod.java
@@ -83,6 +83,6 @@ public class SignEditorMod implements ModInitializer {
     boolean hasEmptyHand(PlayerEntity player) {
         Item mainHandItem = player.getEquippedStack(EquipmentSlot.MAINHAND).getItem();
         Item offHandItem = player.getEquippedStack(EquipmentSlot.OFFHAND).getItem();
-        return mainHandItem is null && !(offHandItem instanceof BlockItem);
+        return mainHandItem == null && !(offHandItem instanceof BlockItem);
     } 
 }


### PR DESCRIPTION
Small change in the code preventing the sign edit interface from opening when the player shift clicks a frame with an object in hand. Solves issue #11.