### PR TITLE
feat: add invisible item frames with amethyst shard

### DIFF
--- a/src/main/java/com/ivanff/signEditor/SignEditorMod.java
+++ b/src/main/java/com/ivanff/signEditor/SignEditorMod.java
@@ -76,7 +76,14 @@ public class SignEditorMod implements ModInitializer {
 
         UseEntityCallback.EVENT.register((player, world, hand, entity, hitResult) -> {
             if (entity instanceof ItemFrameEntity) {
-                if (!player.isSneaking()) {
+                Optional<ItemStack> amethystOption = getAmethystHand(player);
+                if (amethystOption.isPresent()) {
+                    ItemStack amethyst = amethystOption.get();
+                    if (!player.getAbilities().creativeMode) {
+                        amethyst.decrement(1);
+                    }
+                    entity.setInvisible(true);
+                } else if (!player.isSneaking()) {
                     BlockPos pos = entity.getBlockPos();
                     Direction oppositeDirection = entity.getHorizontalFacing().getOpposite();
                     handlePassthrough(player, world, hand, pos, oppositeDirection);
@@ -100,6 +107,14 @@ public class SignEditorMod implements ModInitializer {
         Item offHandItem = player.getEquippedStack(EquipmentSlot.OFFHAND).getItem();
         return !(mainHandItem instanceof BlockItem || mainHandItem instanceof DecorationItem || offHandItem instanceof BlockItem || offHandItem instanceof DecorationItem);
     } 
+
+    Optional<ItemStack> getAmethystHand(PlayerEntity player) {
+        ItemStack mainHandItem = player.getEquippedStack(EquipmentSlot.MAINHAND);
+        ItemStack offHandItem = player.getEquippedStack(EquipmentSlot.OFFHAND);
+        if (mainHandItem.isOf(Items.AMETHYST_SHARD)) return Optional.of(mainHandItem);
+        if (offHandItem.isOf(Items.AMETHYST_SHARD)) return Optional.of(offHandItem);
+        return Optional.empty();
+    }
 
     boolean isHoldingDye(PlayerEntity player) {
         Item mainHandItem = player.getEquippedStack(EquipmentSlot.MAINHAND).getItem();

--- a/src/main/java/com/ivanff/signEditor/mixin/ItemFrameEntityMixin.java
+++ b/src/main/java/com/ivanff/signEditor/mixin/ItemFrameEntityMixin.java
@@ -1,8 +1,13 @@
 package com.ivanff.signEditor.mixin;
 
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.decoration.AbstractDecorationEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.entity.decoration.ItemFrameEntity;
@@ -11,11 +16,20 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 
 @Mixin(ItemFrameEntity.class)
-public abstract class ItemFrameEntityMixin {
+public abstract class ItemFrameEntityMixin extends AbstractDecorationEntity {
+    protected ItemFrameEntityMixin(EntityType<? extends AbstractDecorationEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
     @Inject(at = @At("HEAD"), method = "interact", cancellable = true)
     void onSetRotation(final PlayerEntity player, final Hand hand, final CallbackInfoReturnable<ActionResult> info) {
         if (!player.isSneaking()) {
             info.setReturnValue(ActionResult.FAIL);
         }
+    }
+
+    @Inject(at = @At("HEAD"), method = "removeFromFrame")
+    void onRemoveFrame(ItemStack itemStack, CallbackInfo ci) {
+        this.setInvisible(false);
     }
 }


### PR DESCRIPTION
Allows setting item frames invisible by right click with an Amethyst Shard. When removing the item it's set back to visible again. Consumes the amethyst shard. Could also be swapped to be a glass pane, depending on preference.