### PR TITLE
feat: add edit sign permission

### DIFF
--- a/src/main/java/com/ivanff/signEditor/SignEditorMod.java
+++ b/src/main/java/com/ivanff/signEditor/SignEditorMod.java
@@ -56,7 +56,7 @@ public class SignEditorMod implements ModInitializer {
             if (!(blockEntity instanceof SignBlockEntity)) return ActionResult.PASS;
             if (player.isSneaking()) {
                 if (hasEmptyHand(player)) {
-                    if (FlanCompat.check(world, player, pos) == ActionResult.FAIL) return ActionResult.PASS;
+                    if (FlanCompat.checkEdit(world, player, pos) == ActionResult.FAIL) return ActionResult.PASS;
                     SignBlockEntity signBlock = (SignBlockEntity) blockEntity;
                     ((SignEntityMixin) signBlock).setSignEditable(true);
                     if (signBlock.isEditable()) {
@@ -90,6 +90,7 @@ public class SignEditorMod implements ModInitializer {
     void handlePassthrough(PlayerEntity player, World world, Hand hand, BlockPos pos, Direction oppositeDirection) {
         if (isHoldingDye(player)) return;
         BlockPos hangingPos = pos.add(oppositeDirection.getOffsetX(), oppositeDirection.getOffsetY(), oppositeDirection.getOffsetZ());
+        if (FlanCompat.checkPassthrough(world, player, hangingPos) == ActionResult.FAIL) return;
         BlockState hangingState = world.getBlockState(hangingPos);
         Vec3d hanginPosVec3d = new Vec3d(hangingPos.getX(), hangingPos.getY(), hangingPos.getZ());
         BlockHitResult hangingHitResult = new BlockHitResult(hanginPosVec3d, oppositeDirection, pos, false); 

--- a/src/main/java/com/ivanff/signEditor/SignEditorMod.java
+++ b/src/main/java/com/ivanff/signEditor/SignEditorMod.java
@@ -45,6 +45,7 @@ public class SignEditorMod implements ModInitializer {
     @Override
     public void onInitialize() {
         LOGGER.info("Better Signs & Frames Initializing");
+        FlanCompat.register();
 
         SIGN_TEXT = Registry.register(Registry.LOOT_CONDITION_TYPE, new Identifier("sign_text"), new LootConditionType(new SignTextLootCondition.Serializer()));
 

--- a/src/main/java/com/ivanff/signEditor/compat/FlanCompat.java
+++ b/src/main/java/com/ivanff/signEditor/compat/FlanCompat.java
@@ -1,22 +1,22 @@
 package com.ivanff.signEditor.compat;
 
-import com.ivanff.signEditor.SignEditorMod;
 import io.github.flemmli97.flan.api.ClaimHandler;
 import io.github.flemmli97.flan.api.data.IPermissionContainer;
 import io.github.flemmli97.flan.api.data.IPermissionStorage;
 import io.github.flemmli97.flan.api.permission.ClaimPermission;
+import io.github.flemmli97.flan.api.permission.ObjectToPermissionMap;
 import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.*;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 
 public class FlanCompat {
@@ -26,15 +26,8 @@ public class FlanCompat {
 
     public static void register() {
         if (loader.isModLoaded("flan")) {
-            Identifier[] blocks = Registry.BLOCK.stream().filter(block -> block instanceof AbstractSignBlock).map(AbstractBlock::getLootTableId).map(block -> {
-                SignEditorMod.LOGGER.info("Found Sign {}", block);
-                return block;
-            }).toArray(Identifier[]::new);
-
-            EDITSIGN = PermissionRegistry.registerBlockInteract(
-                    new ClaimPermission("EDITSIGN", () -> new ItemStack(Items.SPRUCE_SIGN), "Permission to edit signs"),
-                    blocks
-            );
+            EDITSIGN = PermissionRegistry.registerBlockInteract(new ClaimPermission("EDITSIGN", () -> new ItemStack(Items.SPRUCE_SIGN), "Permission to edit signs"));
+            ObjectToPermissionMap.registerBlockPredicateMap(block -> block instanceof AbstractSignBlock, () -> EDITSIGN);
         }
     }
     public static boolean canInteract(ServerWorld world, ServerPlayerEntity player, BlockPos pos, ClaimPermission type) {
@@ -44,9 +37,28 @@ public class FlanCompat {
         return container.canInteract(player, type, pos);
     }
 
-    public static ActionResult check(World world, PlayerEntity playerEntity, BlockPos pos) {
+    public static ActionResult checkEdit(World world, PlayerEntity playerEntity, BlockPos pos) {
         if (loader.isModLoaded("flan") && world instanceof ServerWorld serverWorld && playerEntity instanceof ServerPlayerEntity serverPlayerEntity) {
             if (FlanCompat.canInteract(serverWorld, serverPlayerEntity, pos, FlanCompat.EDITSIGN)) {
+                return ActionResult.PASS;
+            }
+            return ActionResult.FAIL;
+        }
+        return ActionResult.PASS;
+    }
+
+    public static ActionResult checkPassthrough(World world, PlayerEntity playerEntity, BlockPos pos) {
+        if (loader.isModLoaded("flan") && world instanceof ServerWorld serverWorld && playerEntity instanceof ServerPlayerEntity serverPlayerEntity) {
+            // Flan doesn't add OPENCONTAINER to it's ObjectToPermissionMap :(
+            BlockEntity be = world.getBlockEntity(pos);
+            if (be instanceof Inventory) {
+                return FlanCompat.canInteract(serverWorld, serverPlayerEntity, pos, PermissionRegistry.OPENCONTAINER) ? ActionResult.PASS : ActionResult.FAIL;
+            }
+
+            BlockState bs = world.getBlockState(pos);
+            ClaimPermission claimPermission = ObjectToPermissionMap.getFromBlock(bs.getBlock());
+            if (claimPermission == null) return ActionResult.PASS;
+            if (FlanCompat.canInteract(serverWorld, serverPlayerEntity, pos, claimPermission)) {
                 return ActionResult.PASS;
             }
             return ActionResult.FAIL;

--- a/src/main/java/com/ivanff/signEditor/compat/FlanCompat.java
+++ b/src/main/java/com/ivanff/signEditor/compat/FlanCompat.java
@@ -1,21 +1,42 @@
 package com.ivanff.signEditor.compat;
 
+import com.ivanff.signEditor.SignEditorMod;
 import io.github.flemmli97.flan.api.ClaimHandler;
 import io.github.flemmli97.flan.api.data.IPermissionContainer;
 import io.github.flemmli97.flan.api.data.IPermissionStorage;
 import io.github.flemmli97.flan.api.permission.ClaimPermission;
 import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 
 public class FlanCompat {
     public static final FabricLoader loader = FabricLoader.getInstance();
 
+    public static ClaimPermission EDITSIGN;
+
+    public static void register() {
+        if (loader.isModLoaded("flan")) {
+            Identifier[] blocks = Registry.BLOCK.stream().filter(block -> block instanceof AbstractSignBlock).map(AbstractBlock::getLootTableId).map(block -> {
+                SignEditorMod.LOGGER.info("Found Sign {}", block);
+                return block;
+            }).toArray(Identifier[]::new);
+
+            EDITSIGN = PermissionRegistry.registerBlockInteract(
+                    new ClaimPermission("EDITSIGN", () -> new ItemStack(Items.SPRUCE_SIGN), "Permission to edit signs"),
+                    blocks
+            );
+        }
+    }
     public static boolean canInteract(ServerWorld world, ServerPlayerEntity player, BlockPos pos, ClaimPermission type) {
         IPermissionStorage storage = ClaimHandler.getPermissionStorage(world);
         IPermissionContainer container = storage.getForPermissionCheck(pos);
@@ -25,7 +46,7 @@ public class FlanCompat {
 
     public static ActionResult check(World world, PlayerEntity playerEntity, BlockPos pos) {
         if (loader.isModLoaded("flan") && world instanceof ServerWorld serverWorld && playerEntity instanceof ServerPlayerEntity serverPlayerEntity) {
-            if (FlanCompat.canInteract(serverWorld, serverPlayerEntity, pos, PermissionRegistry.BREAK) && FlanCompat.canInteract(serverWorld, serverPlayerEntity, pos, PermissionRegistry.PLACE)) {
+            if (FlanCompat.canInteract(serverWorld, serverPlayerEntity, pos, FlanCompat.EDITSIGN)) {
                 return ActionResult.PASS;
             }
             return ActionResult.FAIL;


### PR DESCRIPTION
Apologies for sending so many PRs. I was adding Flan support to another mod and realized I can register permission nodes inside Flan using their API. This adds a bespoke permission node for editing signs that can be configured by Flan users.

Additionally because we handle passthrough interaction, we need to check permissions for that block too, unfortunately the Flan methods to do that don't support everything, so we do some manual checks too.